### PR TITLE
Vision解析結果とLLMプロンプト全文のデバッグログ出力を追加

### DIFF
--- a/src-tauri/src/post_processor.rs
+++ b/src-tauri/src/post_processor.rs
@@ -227,12 +227,20 @@ pub async fn post_process(
         app_prompt_rules,
         context,
     );
+    post_process_with_prompt(model, api_key, &prompt).await
+}
+
+pub(crate) async fn post_process_with_prompt(
+    model: LlmModel,
+    api_key: &str,
+    prompt: &str,
+) -> AppResult<PostProcessResult> {
     match model {
         LlmModel::Gemini25FlashLite | LlmModel::Gemini25FlashLiteAudio => {
-            post_process_gemini(api_key, &prompt).await
+            post_process_gemini(api_key, prompt).await
         }
         LlmModel::Gpt4oMini | LlmModel::Gpt5Nano => {
-            post_process_openai(api_key, model, &prompt).await
+            post_process_openai(api_key, model, prompt).await
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Vision解析で得られたコンテキスト（summary / terms）と、LLMに送信する最終プロンプト全文をログに出力してパイプライン動作を可視化するため。
- 既存のログフォーマット（`emit_log`）を流用してデバッグ情報をUI側で確認できるようにするため。

### Description
- `src-tauri/src/lib.rs`のVisionタスク完了箇所で`Vision解析結果: summary="...", terms=[...]`を`emit_log`で出力するよう追加し、`terms`はJSONライクな配列表記で整形しています。 
- `stop_recording`内のLLM呼び出し前に`post_processor::build_prompt`でプロンプトを事前生成し、`emit_log`で`LLMプロンプト:
{prompt}`を出力するように変更しました。 
- `src-tauri/src/post_processor.rs`に`post_process_with_prompt`ヘルパーを追加し、既存の`post_process`はプロンプトを組み立てた後このヘルパーを呼ぶようにリファクタリングしました。 
- 変更箇所は`src-tauri/src/lib.rs`と`src-tauri/src/post_processor.rs`です。 

### Testing
- 自動化テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dcc3082948324b27e7f2601b04f0f)